### PR TITLE
added tableau template parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Below is a summary of all supported config options.
 | Option        | Scope           | Description  |
 |:------------- |:-------------|:-----|
 | ```app.max_parallel_tasks```      | global | The number of tasks to run in parallel. |
+| ```app.template```      | global | Override name of Tableau Template Workbook to generate |
 | ```app.log_level```      | global | Output log level. ```debug``` shows full requests and responses. ```info```, ```warn```, ```debug```, ```trace``` |
 | ```app.date_format```      | global | Format used for all data outputs. Defaults to ```YYYY-MM-DD HH:mm:ss```. See http://momentjs.com/docs/#/displaying/format/ |
 | ```end``` | global | OPTIONAL. unix timestamp. Defaults to now UTC |
@@ -560,7 +561,7 @@ Each workbook is designed based on a specific use case as detailed below. Simply
 
 ### Custom Tableau Workbooks
 
-PEPP will automatically check the ```/tableau-templates``` directory for a Tableau workbook (.twb) file with an identical name to that of the config file being executed. If a corresponding workbook is found, it will be copied to the output directory along with the other output files rewriting the directory paths within the workbook accordingly.
+PEPP will automatically check the ```/tableau-templates``` directory for a Tableau workbook (.twb) file with an identical name to that of the config file being executed. If a corresponding workbook is found, it will be copied to the output directory along with the other output files rewriting the directory paths within the workbook accordingly. You can specify to use a template with a different name by using the ```app.template``` property in your config file. (Do not include the .twb extension in this property.)
 
 With this in mind, it then becomes easy to create new custom Tableau workbooks simply by developing a config recipe an associated workbook, and copying the ```.tbx``` file back in to the ```/tableau-templates``` directory. This is especially useful for refreshing data sets.
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -9,6 +9,8 @@ const log = require("./helpers/logger");
 
 let format = process.env.FORMAT || (config.has('app.format') ? config.get('app.format').toLowerCase() : "json");
 let writeConfig = process.env.FORMAT|| (config.has('app.write_to_file') ? config.get('app.write_to_file') : "false");
+let tableauTemplate = process.env.FORMAT || config.has('app.template') ? config.get('app.template') : process.env.NODE_ENV;
+
 
 const supportedFormats = ["json", "csv"];
 const ts = moment().format("YYYY-MM-DD-HH.mm.ss");
@@ -17,7 +19,7 @@ const dir = "./output/" + process.env.NODE_ENV + "-" + ts;
 
 function fileExists(){
     try{
-        fs.accessSync('./tableau-templates/' + process.env.NODE_ENV + '.twb');
+        fs.accessSync('./tableau-templates/' + tableauTemplate + '.twb');
         return true;
     }catch(e){
         return false;
@@ -32,9 +34,9 @@ if(fileExists() === true && writeConfig === true){
         fs.mkdirSync(dir);
     }
 
-    let destFile = dir + '/' + process.env.NODE_ENV + '.twb';
+    let destFile = dir + '/' + tableauTemplate + '.twb';
 
-    fse.copy('./tableau-templates/' + process.env.NODE_ENV + '.twb', destFile, function (err) {
+    fse.copy('./tableau-templates/' + tableauTemplate + '.twb', destFile, function (err) {
         if (err) {
             log.error("Unable to copy Tableau source file.");
         }


### PR DESCRIPTION
@haganbt I added the ability to specify a template  you want to use explicitly. That way if you have multiple config files (eg using different indexes) to generate the same Tableau Workbook, you don't need to keep copying and renaming Tableau Templates.