### PR TITLE
Add retry logic for failed /task GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PEPP - PYLON Exporter++
 
-<sub><sup>V2.2.4 [Changelog](https://github.com/haganbt/pepp/wiki/Changelog)</sup></sub>
+<sub><sup>V2.2.5 [Changelog](https://github.com/haganbt/pepp/wiki/Changelog)</sup></sub>
 
 PEPP is a utility for exporting data from DataSift's PYLON product in either JSON or CSV format, optionally saving the data to local file. PEPP also supports the ability to automatically generate Tableau workbooks and comes equipped with a number of use case driven examples out of the box.
 
@@ -15,6 +15,7 @@ Features:
  * Result set merging
  * Result set to query inheritance
  * Request queue with concurrency limit
+ * Retry logic to handle API errors
  * Automated Tableau workbook generation
 
 ### DISCLAIMER: This library is in no way associated with or supported by DataSift and hence any questions or issues issues should be logged [here](https://github.com/haganbt/pepp/issues).

--- a/lib/helpers/retry.js
+++ b/lib/helpers/retry.js
@@ -1,0 +1,54 @@
+//todo - support POST as well as GET requests
+
+"use strict";
+
+const attempts = 2;
+
+let failedRequests = {};
+
+/**
+ * Count failed requests using the GET URI as the key
+ *
+ * @param req - req object
+ */
+const setFailed = function setFailed(req){
+
+    let uri = req.uri;
+
+    failedRequests[uri] = failedRequests[uri] || 0;
+    failedRequests[uri] ++;
+};
+
+
+/**
+ * Returns the current number of retries
+ *
+ * @param req
+ * @returns int
+ */
+const getAttempts = function getAttempts(req){
+    let uri = req.uri;
+    return failedRequests[uri];
+};
+
+
+/**
+ *
+ * @param req
+ * @returns {boolean}
+ */
+const shouldRetry = function shouldRetry(req){
+
+    let uri = req.uri;
+
+    if(failedRequests[uri] <= attempts){
+        return true;
+    }
+    //console.log(JSON.stringify(failedRequests, undefined, 4));
+    return false;
+};
+
+
+exports.setFailed = setFailed;
+exports.shouldRetry = shouldRetry;
+exports.getAttempts = getAttempts;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -5,11 +5,10 @@ const config = require('config');
 const _ = require('underscore');
 const moment = require('moment');
 
-
-const cacheHelper = require('./helpers/cache');
 const request = require('./request');
 const taskManager = require('./taskManager');
 const taskHelper = require('./helpers/task');
+const cacheHelper = require('./helpers/cache');
 const log = require("./helpers/logger");
 const requestFactory = require("./requestFactory").requestFactory;
 
@@ -148,6 +147,13 @@ const queueRequest = function queueRequest(requestObj, normalizedTask) {
         }
 
     }).catch(function (err) {
+
+        // Req failed, drop from cache so we return a partial data set
+        if(normalizedTask.cache) {
+            log.warn("Data dropped due to task failure with key: \"" + normalizedTask.cache.mergeKey + "\"");
+            cacheHelper.setFailed(normalizedTask.cache);
+        }
+
 
         if(err.error && err.error.error){
             log.error("MESSAGE:", err.error.error);

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,7 @@ const queue = require('./queue');
 const requestFactory = require("./requestFactory").requestFactory;
 const cacheHelper = require('./helpers/cache');
 const requestStats = require("./helpers/requestStats");
+const retryHelper = require("./helpers/retry");
 const spinner = require("./helpers/spinner");
 
 //Expose req/res debug
@@ -67,15 +68,15 @@ const recursivePoll = function recursivePoll(normalizedTask, requestObj, taskRes
     const t = 10000;
     let count = 1;
 
+    const getTask = {
+        "api_resource": "get_task",
+        "taskId": taskResponse.id
+    };
+
+    const getRequest = requestFactory(getTask);
+
     return new Promise(function(resolve, reject) {
         function next() {
-
-            let getTask = {
-                "api_resource": "get_task",
-                "taskId": taskResponse.id
-            };
-
-            const getRequest = requestFactory(getTask);
 
             log.trace("Polling /task GET request for:", taskResponse.id);
 
@@ -107,9 +108,27 @@ const recursivePoll = function recursivePoll(normalizedTask, requestObj, taskRes
                     setTimeout(next, t * count++);
                 })
                 .catch(function (err) {
-                    // Set GET request in error
-                    err.request = getRequest;
-                    return reject(err);
+
+                    // count the failed request
+                    retryHelper.setFailed(getRequest);
+
+                    if(retryHelper.shouldRetry(getRequest) === true){
+
+                        let attempts = retryHelper.getAttempts(getRequest);
+
+                        log.warn("GET task " + taskResponse.id + " failed (error " + err.statusCode + "). Retry "
+                            + attempts + "...");
+
+                        next();
+
+                    } else {
+
+                        log.error("/GET failed after 3 attempts, killing request " + taskResponse.id);
+
+                        // Set GET request in error
+                        err.request = getRequest;
+                        return reject(err);
+                    }
                 });
         }
         setTimeout(next, 10000); // wait before first poll

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pepp",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "PYLON Exporter ++",
   "main": "app.js",
   "engines": {


### PR DESCRIPTION
This PR improves error handling in two ways:

* failed /task GET requests are retried 3 times
* failed /task and /analyze POST requests now delete the expected result set from the cache so that a partial data set is returned where possible.