### PR TITLE
Implement commandline arguments and task grouping for partial recipe execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Analysis Tags can be used anywhere a regular target would be used, with the exce
 
 ## Config File Selection
 
+### Config File Selection by Environment Variable
+
 To specify which config file to use, set the ```NODE_ENV``` environment variable:
 
 On a Mac:
@@ -312,6 +314,14 @@ NOTE: only specify the config file name. Omit the filetype extension, i.e. ```.j
 
 If ```NODE_ENV``` is not specified, the ```demo``` config file will be used i.e.load the ```/config/demo.js```
 config file.
+
+### Config File Selection by Commandline Argument
+
+Alternatively, the filename may be specified by the first commandline argument to the app:
+
+```
+node app.js myConfigFile
+```
 
 ### Config File Directory
 
@@ -340,6 +350,7 @@ Below is a summary of all supported config options.
 | ```id``` | merged task | A unique identifier for each merged task result set. Used to distinguish between results on output. |
 | ```only``` | task | Only execute the specific task(s) with this flag set. Must evaluate to boolean truthy: ```true```, ```"true"```, ```1```, ```"yes"```  |
 | ```skip``` | task | Do not execute the specific task(s) with this flag set. Must evaluate to boolean truthy: ```true```, ```"true"```, ```1```, ```"yes"```  |
+| ```group``` | task | Assign task to the execution group specified. Groups can be selected at runtime via commandline argument or PEPP_GROUP |
 | ```start``` | global task | OPTIONAL. start time - unix timestamp. Defaults to now -30 days UTC |
 | ```target``` | freqDist task | PYLON analyze target parameter |
 | ```threshold``` | freqDist task | OPTIONAL. PYLON parameter to identify the threshold. Defaults to 200 of omitted |
@@ -468,6 +479,23 @@ module.exports = {
     ...
 ```
 
+### Execution Groups
+
+When the ```group``` property is assigned on a task, it defines all tasks labeled with the same group value as a set. These groups can be useful when your recipe file has multiple logical groups of tasks that are often run together. For example, all tasks associated with brand monitoring vs. those for content monitoring, or when running all tasks in your recipe would exceed your hourly analyze limit.
+
+At runtime, the group to be executed may be specified on the commandline:
+
+```
+node app.js myrecipe mygroup
+```
+
+or via the ```PEPP_GROUP``` environment variable:
+
+```
+export PEPP_GROUP=mygroup
+```
+
+The ```skip``` and ```only``` properties may also be used in conjunction with the execution group functionality. In the context of a single group, if a task is designated as ```only```, other tasks in the group without this flag will not be executed. When ```skip``` is used, the identified task will not be executed in the context of the group. NOTE: When no group is specified, the group context does not apply, and any task with ```only``` specified will be executed from the recipe.
 
 ## Index Credentials
 

--- a/app.js
+++ b/app.js
@@ -1,13 +1,11 @@
 "use strict";
 
-let execution_group;
 if(process.argv.length > 2 && process.argv[2]) {
     process.env.NODE_ENV = process.argv[2];
-    execution_group = process.argv[3];
+    process.env.PEPP_GROUP = process.argv[3];
 }
 
 process.env.NODE_ENV = process.env.NODE_ENV || "demo";
-execution_group = execution_group || process.env.PEPP_GROUP;
 
 const _ = require('underscore');
 const figlet = require('figlet');
@@ -28,7 +26,7 @@ spinner.start();
 log.info(figlet.textSync(process.env.NODE_ENV));
 console.log("\n\n");
 
-const normalizedTasks = _.compact(taskManager.loadConfigTasks(null, execution_group));
+const normalizedTasks = _.compact(taskManager.loadConfigTasks(null, process.env.PEPP_GROUP));
 
 if(normalizedTasks.length == 0) {
     log.info("No tasks found.");

--- a/app.js
+++ b/app.js
@@ -1,5 +1,13 @@
 "use strict";
+
+let execution_group;
+if(process.argv.length > 2 && process.argv[2]) {
+    process.env.NODE_ENV = process.argv[2];
+    execution_group = process.argv[3];
+}
+
 process.env.NODE_ENV = process.env.NODE_ENV || "demo";
+execution_group = execution_group || process.env.PEPP_GROUP;
 
 const _ = require('underscore');
 const figlet = require('figlet');
@@ -20,10 +28,15 @@ spinner.start();
 log.info(figlet.textSync(process.env.NODE_ENV));
 console.log("\n\n");
 
-const normalizedTasks = taskManager.loadConfigTasks();
+const normalizedTasks = _.compact(taskManager.loadConfigTasks(null, execution_group));
+
+if(normalizedTasks.length == 0) {
+    log.info("No tasks found.");
+    spinner.stop();
+    return;
+}
 
 normalizedTasks.forEach(task => {
-
     const reqObj = requestFactory(task);
 
     queue.queueRequest(reqObj, task)

--- a/lib/file.js
+++ b/lib/file.js
@@ -13,7 +13,9 @@ let tableauTemplate = config.has('app.template') ? config.get('app.template') : 
 
 const supportedFormats = ["json", "csv"];
 const ts = moment().format("YYYY-MM-DD-HH.mm.ss");
-const dir = "./output/" + process.env.NODE_ENV + "-" + ts;
+
+let dir_suffix = process.env.PEPP_GROUP ? "-" + process.env.PEPP_GROUP : "";
+const dir = "./output/" + process.env.NODE_ENV + "-" + ts + dir_suffix;
 
 
 function fileExists(){

--- a/lib/helpers/task.js
+++ b/lib/helpers/task.js
@@ -70,7 +70,7 @@ module.exports = {
      * @returns {boolean}
      */
     isValidKey: function (str) {
-        let arr = ["baseline", "filter", "interval", "span", "threshold", "target", "id", "name", "index", "analysis_type", "subscription_id", "api_resource", "only", "skip"];
+        let arr = ["baseline", "filter", "interval", "span", "threshold", "target", "id", "name", "index", "analysis_type", "subscription_id", "api_resource", "only", "skip", "group"];
         return (arr.indexOf(str) != -1);
     },
 

--- a/lib/taskManager.js
+++ b/lib/taskManager.js
@@ -87,6 +87,10 @@ const normalizeTask = function normalizeTask(tasks, analysis_type, mergedName, g
             requestParams.skip = task.skip;
         }
 
+        if(_.has(task,'group')){
+            requestParams.group = task.group;
+        }
+
         requestParams.name = mergedName || task.name || taskHelper.generateName(task);
 
         if(globalFilter){
@@ -360,7 +364,7 @@ const extractTasks = function extractTasks(inObj){
  *
  * @return [{tasks}] - array of request objects
  */
-const loadConfigTasks = function loadConfigTasks(configTest) {
+const loadConfigTasks = function loadConfigTasks(configTest, group) {
 
     let configObj = configTest || config.get('analysis');
     let globalFilter = (config.has('filter') ? config.get('filter') : undefined);
@@ -400,8 +404,11 @@ const loadConfigTasks = function loadConfigTasks(configTest) {
     //run specific tasks only using "only" flag
     let runOnly = [];
     for (var key in allNormalizedTasks) {
-        if(allNormalizedTasks[key].only && boolean(allNormalizedTasks[key].only) === true) {
-            runOnly.push(allNormalizedTasks[key]);
+        // if group specified, find the task with the "only" flag on within the group
+          if(allNormalizedTasks[key].only && boolean(allNormalizedTasks[key].only) === true) {
+            if((group && allNormalizedTasks[key].group == group) || !group) {
+                runOnly.push(allNormalizedTasks[key]);
+            }
         }
     }
 
@@ -413,11 +420,19 @@ const loadConfigTasks = function loadConfigTasks(configTest) {
         log.info(runOnly.length + " task" + s + " set as run only.");
     }
 
-    //drop specific tasks using rhe "skip" flag
+    // remove tasks not in scope via group or skip flags
     for (var key in allNormalizedTasks) {
-
+        // if a group is specified, remove non-matching items from the list
+        //   allow users to also use the skip key in these contexts
+        var annotated_name = allNormalizedTasks[key].group ? allNormalizedTasks[key].group + "." : ""
+        if(group && allNormalizedTasks[key].group != group) {
+            log.info("Skipping task:", annotated_name + allNormalizedTasks[key].name, "because it does not belong to", group);
+            delete allNormalizedTasks[key];
+            continue;
+        }
+        // drop specific tasks using the "skip" flag
         if(allNormalizedTasks[key].skip && boolean(allNormalizedTasks[key].skip) === true) {
-            log.info("Skipping task: ", allNormalizedTasks[key].name);
+            log.info("Skipping task:", annotated_name + allNormalizedTasks[key].name);
             delete allNormalizedTasks[key];
         }
     }


### PR DESCRIPTION
Allows for specification of the PEPP recipe via commandline (arg0) and an optional (sub)group from the recipe to be executed (arg1 or PEPP_GROUP).

Individual tasks can be assigned to a group and executed in sets. Includes compatibility with "skip" and "only" flags within the group context.