### PR TITLE
Fixes #110, ensuring PEPP_GROUP is a group or an empty string

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 
 if(process.argv.length > 2 && process.argv[2]) {
     process.env.NODE_ENV = process.argv[2];
-    process.env.PEPP_GROUP = process.argv[3];
+    process.env.PEPP_GROUP = process.argv[3] || '';
 }
 
 process.env.NODE_ENV = process.env.NODE_ENV || "demo";


### PR DESCRIPTION
Simple change that allows specification of the config file/recipe from the command line (without requiring a group)